### PR TITLE
Fix osx build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,10 @@ OS := $(shell uname)
 ifeq ($(OS),Darwin)
 LDFLAGS += -flat_namespace -undefined suppress -dynamiclib
 SO = dylib
-else
+else 
 LDFLAGS += -shared
 SO = so
+INSTALL += -D
 endif
 
 all: libsfark.$(SO)
@@ -25,5 +26,5 @@ libsfark.$(SO): $(OBJECTS)
 	$(CXX) -shared $(LDFLAGS) $(OBJECTS) -o libsfark.$(SO)
 
 install: libsfark.$(SO) sfArkLib.h
-	$(INSTALL) -D libsfark.$(SO) $(DESTDIR)/usr/local/lib/libsfark.$(SO)
-	$(INSTALL) -D sfArkLib.h $(DESTDIR)/usr/local/include/sfArkLib.h
+	$(INSTALL) libsfark.$(SO) $(DESTDIR)/usr/local/lib/libsfark.$(SO)
+	$(INSTALL) sfArkLib.h $(DESTDIR)/usr/local/include/sfArkLib.h


### PR DESCRIPTION
Updated to build library correctly on OSX. Have tested by manually linking into sfArkXTm - have not yet fixed that build.

make install still not quite right on osx.

Fixes #1 
