### PR TITLE
Edited install directories.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,5 @@ libsfark.$(SO): $(OBJECTS)
 	$(CXX) -shared $(LDFLAGS) $(OBJECTS) -o libsfark.$(SO)
 
 install: libsfark.$(SO) sfArkLib.h
-	$(INSTALL) libsfark.$(SO) $(DESTDIR)/usr/local/lib/libsfark.$(SO)
-	$(INSTALL) sfArkLib.h $(DESTDIR)/usr/local/include/sfArkLib.h
+	$(INSTALL) libsfark.$(SO) $(DESTDIR)/usr/lib/libsfark.$(SO)
+	$(INSTALL) sfArkLib.h $(DESTDIR)/usr/include/sfArkLib.h


### PR DESCRIPTION
When using sfarkxtc, it couldn't open libsfark.so unless it was in /usr/lib(64).