### PR TITLE
bug fix: any output path can now be provided, even if it's in a different directory.

### DIFF
--- a/sfklFile.cpp
+++ b/sfklFile.cpp
@@ -76,31 +76,12 @@ int	ChkErr(const char *message, const char *filename);
 
 void OpenOutputFile(const char *FileName)
 {
-  #if 1
-  int i;
-  int lenInFileName = strlen(InFileName); 
-  for (i = lenInFileName; i >= 0; i--)
-  {
-    char c = InFileName[i];
-    if (c == '\\'  || c == '/')	break;
-  }
-  
-  if (i < 0)
-    strncpy(OutFileName, FileName, sizeof(OutFileName));
-  else
-  {
-      strncpy(OutFileName, InFileName, i+1);
-      strncpy(OutFileName+i+1, FileName, sizeof(OutFileName) - (i+1));
-  }
-  #else
   strncpy(OutFileName, FileName, sizeof(OutFileName));
-  #endif
   
   //strcat(OutFileName, TempFileExt);	// Add temporary extension
   
   OutputFileHandle = CREATEFILE(OutFileName);
   if (OutputFileHandle == INVALID_HANDLE_VALUE)  ChkErr("create", OutFileName);
-  return;
 }
 // =================================================================================
 
@@ -111,7 +92,6 @@ void OpenInputFile(const char *FileName)
   InputFileHandle = OPENFILE(FileName);
   if (InputFileHandle == INVALID_HANDLE_VALUE)  ChkErr("open", InFileName);
   //else printf("OpenInputFile successful\n");
-  return;
 }
 // =================================================================================
 

--- a/sfklString.cpp
+++ b/sfklString.cpp
@@ -18,14 +18,68 @@
 // along with sfArkLib.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <string.h>
+#include <stdio.h>
+#include "wcc.h"
 
-const char *GetFileExt(const char *FileName)
+char *GetFileExt(char *FileName)
 {
   // return pointer to (final) file extension including the dot e.g. '.txt'
-  const char *p;
+  // returns NULL if file is not found
+  char *p;
 
-  for(p = FileName + strlen(FileName); p > FileName &&  *p != '.'; p--) {}
-  if (*p == '.')  p = FileName + strlen(FileName);
-	return p;
+  for(p = FileName + strlen(FileName); p > FileName; p--)
+  {
+    if (*p == '.')
+    {
+      return p;
+    }
+    else if (*p == '/' || *p == '\\')
+    {
+      return NULL;
+    }
+  }
+  
+  return NULL;
 }
 
+char *StrncpyEnsureNul(char *destination, const char *source, int num)
+{
+  if (num == 0 || !destination || !source)
+  {
+    return destination;
+  }
+  else
+  {
+    // same as strncpy, except it ensures the result is nul-terminated.
+    char *ret = strncpy(destination, source, num - 1);
+    destination[num - 1] = 0;
+    return ret;
+  }
+}
+
+void ChangeFileExt(const char *path, const char *newExtension, char *out, int outSize)
+{
+  if (strlen(path) >= MAX_FILEPATH)
+  {
+    // path is too long for our buffer
+    out[0] = 0;
+    return;
+  }
+  
+  char pathWithoutExtension[MAX_FILEPATH] = "";
+  StrncpyEnsureNul(pathWithoutExtension, path, sizeof(pathWithoutExtension));
+  char *p = GetFileExt(pathWithoutExtension);
+  if (p)
+  {
+    // add null-terminator where the '.' used to be.
+    *p = 0;
+  }
+  
+  // if there's no extension in the input, we'll simply append the new extension.
+  int ret = snprintf(out, outSize, "%s%s", pathWithoutExtension, newExtension);
+  if (ret < 0 || ret >= outSize)
+  {
+    out[0] = 0;
+    return;
+  }
+}

--- a/wcc.h
+++ b/wcc.h
@@ -205,3 +205,7 @@ extern long	UnLPC(AWORD *OutBuf, AWORD *InBuf, short bufsize, short nc, ULONG *F
 
 // sfArkLib_Zip...
 extern ULONG	UnMemcomp(const BYTE *InBuf, int InBytes, BYTE *OutBuf, int OutBufLen);
+
+ // sfArkLib_String...
+extern char *StrncpyEnsureNul(char *destination, const char *source, int num);
+void ChangeFileExt(const char *path, const char *newExtension, char *out, int outSize);


### PR DESCRIPTION
also, when using the original .sf2 filename as an output name,
exit with an error if it contains dir sep characters,
for security reasons.