### PR TITLE
fix portability issues (correctness of output)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,11 +2,19 @@ INSTALL?=install
 
 OBJECTS=sfklCoding.o sfklDiff.o sfklLPC.o sfklZip.o sfklCrunch.o sfklFile.o sfklString.o
 
-ENDIANNESS=LITTLE_ENDIAN
-
-CXXFLAGS+=-fPIC -D__$(ENDIANNESS)__ -Wall -Wextra
+CXXFLAGS+=-fPIC -Wall -Wextra -ffloat-store
 
 OS := $(shell uname)
+
+ifneq (,$(filter Linux GNU/kFreeBSD GNU,${OS}))
+CPPFLAGS+=-DUSE_ENDIAN_H
+else ifneq (,$(findstring BSD,${OS}))
+CPPFLAGS+=-DUSE_SYS_ENDIAN_H
+else
+ENDIANNESS=LITTLE_ENDIAN
+CPPFLAGS+=-DUSE_MANUAL_ENDIANNESS -DMANUAL_${ENDIANNESS}
+endif
+
 ifeq ($(OS),Darwin)
 LDFLAGS += -flat_namespace -undefined suppress -dynamiclib
 SO = dylib

--- a/sfklCoding.cpp
+++ b/sfklCoding.cpp
@@ -215,7 +215,7 @@ int ReadHeader(V2_FILEHEADER *FileHeader, BYTE *fbuf, int bufsize)
     HeaderLen = V2_FILEHEADER_SIZE - sizeof(FileHeader->FileName) + strlen(FileHeader->FileName) + 1;
 
     // If we get this far, there's a good chance we've got the header...
-    #ifdef	__BIG_ENDIAN__
+    #if BYTE_ORDER == BIG_ENDIAN
       // FixEndians of all multi-byte integers (currently only relevent to Mac)
       #define FIXENDIAN(field)	FixEndian(&(FileHeader->field), sizeof(FileHeader->field))
       FIXENDIAN(Flags); 	FIXENDIAN(OriginalSize); 	FIXENDIAN(CompressedSize);
@@ -542,7 +542,7 @@ int ProcessNextBlock(BLOCK_DATA *Blk)
 	  DecompressFast(Blk, NumWords);										// Decompress
 
 	//printf("B4 WriteOutputFile: %ld\n", adler32(0, (const BYTE *) Blk->SrcBuf, n) & 0xffff);
-	#ifdef __BIG_ENDIAN__
+	#if BYTE_ORDER == BIG_ENDIAN
 	#define	WFIX(I)		s = bp[I+0]; bp[I+0] = bp[I+1]; bp[I+1] = s;
 	BYTE *bp = (BYTE *) Blk->SrcBuf; BYTE *ep = bp + n;
 	do {						
@@ -853,15 +853,11 @@ int Decode(const char *InFileName, const char *ReqOutFileName)
 // Adjust integer held at *num for this machine's endian system
 void FixEndian(void *num, int nsize)
 {
-#ifdef	__BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
   int i;
   BYTE bb[4];
   for (i = 0; i < nsize; i++)  bb[i] = ((BYTE *) num)[i];
   for (i = 0; i < nsize; i++)  ((BYTE *) num)[i] = bb[nsize-1-i];
-#else 
-  #ifndef __LITTLE_ENDIAN__
-  #error ENDIAN system undefined
-  #endif
 #endif
 }
 

--- a/sfklCrunch.cpp
+++ b/sfklCrunch.cpp
@@ -72,7 +72,7 @@ static BYTE nb[1 << (AWORD_BITS-1)]; // Array to hold number of bits needed to r
   bioBits = LOWBITS(bioBits, bioRemBits)		
   
 // =========================================================================
-#ifdef	__BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
 
 #define	WFIX(I)		s = bp[I+0]; bp[I+0] = bp[I+1]; bp[I+1] = s;
 // Read from disk if needed, and fix endians

--- a/wcc.h
+++ b/wcc.h
@@ -17,10 +17,30 @@
 // You should have received a copy of the GNU General Public License
 // along with sfArkLib.  If not, see <http://www.gnu.org/licenses/>.
 
-#ifndef	__BIG_ENDIAN__
-#ifndef __LITTLE_ENDIAN__
+#if defined(USE_MANUAL_ENDIANNESS) && \
+    (defined(MANUAL_LITTLE_ENDIAN) || defined(MANUAL_BIG_ENDIAN))
+#define LITTLE_ENDIAN	1234
+#define BIG_ENDIAN	4321
+#ifdef MANUAL_LITTLE_ENDIAN
+#define BYTE_ORDER	LITTLE_ENDIAN
+#else
+#define BYTE_ORDER	BIG_ENDIAN
+#endif
+#elif defined(USE_SYS_ENDIAN_H)
+/* BSD */
+#include <sys/endian.h>
+#elif defined(USE_ENDIAN_H)
+/* GNU */
+#include <endian.h>
+#endif
+
+#if !defined(LITTLE_ENDIAN) || !defined(BIG_ENDIAN) || !defined(BYTE_ORDER)
 #error ENDIAN system undefined
 #endif
+
+#if (BYTE_ORDER != LITTLE_ENDIAN) && (BYTE_ORDER != BIG_ENDIAN)
+/* PDP endian or something */
+#error only big or little endian systems are supported
 #endif
 
 #include	"sfArkLib.h"
@@ -126,7 +146,7 @@ typedef ULONG						BIOWORD2;
 #define	RETURN_ON_ERROR()	if (GlobalErrorFlag != SFARKLIB_SUCCESS)  return(GlobalErrorFlag)
 #define	JUMP_ON_ERROR(label)	if (GlobalErrorFlag != SFARKLIB_SUCCESS)  goto label
 
-#ifdef	__BIG_ENDIAN__
+#if BYTE_ORDER == BIG_ENDIAN
     #define FIX_ENDIAN16(w)	((((BYTE) w) << 8) | (((USHORT)w) >> 8))
 #else
     #define FIX_ENDIAN16(w)	(w)	


### PR DESCRIPTION
- automatically determine endianness on common OSes
- use -ffloat-store to force floating point operation precision