### PR TITLE
more fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,22 @@ endif
 INCDIR = ${PREFIX}/include
 
 all: libsfark.$(SO)
+ifneq (,$(strip ${USE_SOLINK}))
+	set -ex; for solink in ${USE_SOLINK}; do \
+		rm -f libsfark.$$solink; \
+		ln -s libsfark.$(SO) libsfark.$$solink; \
+	done
+endif
 
 .PHONY: clean
 
 clean:
 	-rm *.o libsfark.$(SO)
+ifneq (,$(strip ${USE_SOLINK}))
+	set -ex; for solink in ${USE_SOLINK}; do \
+		rm -f libsfark.$$solink; \
+	done
+endif
 
 test: libsfark.$(SO)
 	-rm -rf sfarkxtc

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ test: libsfark.$(SO)
 	rm -rf sfarkxtc
 
 libsfark.$(SO): $(OBJECTS)
-	$(CXX) -shared $(LDFLAGS) $(OBJECTS) -o libsfark.$(SO)
+	$(CXX) -shared $(LDFLAGS) $(OBJECTS) -o libsfark.$(SO) -lz
 
 # It is unclear to me whether /usr/local/* is the proper location on
 # OSX, as reportedly it's not on the clang path by default there. Let

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 INSTALL?=install
+USE_SOLINK:=
 
 OBJECTS=sfklCoding.o sfklDiff.o sfklLPC.o sfklZip.o sfklCrunch.o sfklFile.o sfklString.o
 
@@ -12,9 +13,29 @@ LDFLAGS += -flat_namespace -undefined suppress -dynamiclib
 SO = dylib
 else 
 LDFLAGS += -shared
-SO = so
+SHLIB_MAJOR:=0
+SHLIB_MINOR:=0
+SHLIB_PATCHLEVEL:=0
+ifneq (,$(filter Linux GNU/kFreeBSD GNU,${OS}))
 INSTALL += -D
+USE_SOLINK:=so.${SHLIB_MAJOR} so
+SO = so.${SHLIB_MAJOR}.${SHLIB_MINOR}.${SHLIB_PATCHLEVEL}
+LDFLAGS += -Wl,-soname,libsfark.so.${SHLIB_MAJOR}
+else ifneq (,$(findstring BSD,${OS}))
+# OpenBSD/MirBSD, might apply to NetBSD, FreeBSD/MidnightBSD might differ
+SO = so.${SHLIB_MAJOR}.${SHLIB_MINOR}
+else
+SO = so
 endif
+endif
+
+PREFIX ?= /usr/local
+ifdef DEB_HOST_MULTIARCH
+LIBDIR = ${PREFIX}/lib/${DEB_HOST_MULTIARCH}
+else
+LIBDIR = ${PREFIX}/lib
+endif
+INCDIR = ${PREFIX}/include
 
 all: libsfark.$(SO)
 
@@ -36,5 +57,11 @@ libsfark.$(SO): $(OBJECTS)
 # OSX, as reportedly it's not on the clang path by default there. Let
 # me know if you know how this should be done there :).
 install: libsfark.$(SO) sfArkLib.h
-	$(INSTALL) libsfark.$(SO) $(DESTDIR)/usr/local/lib/libsfark.$(SO)
-	$(INSTALL) sfArkLib.h $(DESTDIR)/usr/local/include/sfArkLib.h
+	$(INSTALL) libsfark.$(SO) ${DESTDIR}${LIBDIR}/libsfark.$(SO)
+	$(INSTALL) sfArkLib.h ${DESTDIR}${INCDIR}/sfArkLib.h
+ifneq (,$(strip ${USE_SOLINK}))
+	set -ex; for solink in ${USE_SOLINK}; do \
+		rm -f ${DESTDIR}${LIBDIR}/libsfark.$$solink; \
+		ln -s libsfark.$(SO) ${DESTDIR}${LIBDIR}/libsfark.$$solink; \
+	done
+endif

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS += -flat_namespace -undefined suppress -dynamiclib
 SO = dylib
 else 
 LDFLAGS += -shared
-SHLIB_MAJOR:=0
+SHLIB_MAJOR:=1
 SHLIB_MINOR:=0
 SHLIB_PATCHLEVEL:=0
 ifneq (,$(filter Linux GNU/kFreeBSD GNU,${OS}))

--- a/sfklCoding.cpp
+++ b/sfklCoding.cpp
@@ -649,7 +649,7 @@ bool	ExtractTextFile(BLOCK_DATA *Blk, ULONG FileType)
 
 		if (n <= 0  ||  n > ZBUF_SIZE)								// Check for valid block length
 		{
-			sprintf(MsgTxt, "ERROR - Invalid length for %s file (apparently %ld bytes) %s", OutFileName, n, CorruptedMsg);
+			sprintf(MsgTxt, "ERROR - Invalid length for %s file (apparently %d bytes) %s", OutFileName, n, CorruptedMsg);
 			msg(MsgTxt, MSG_PopUp);
 			GlobalErrorFlag = SFARKLIB_ERR_CORRUPT;
 			return false;
@@ -842,7 +842,7 @@ int Decode(const char *InFileName, const char *ReqOutFileName)
 	return EndProcess(GlobalErrorFlag);
     }
 
-    sprintf(MsgTxt, "Created %s (%ld kb) successfully.", OutFileNameMain, Blk.TotBytesWritten/1024);
+    sprintf(MsgTxt, "Created %s (%d KiB) successfully.", OutFileNameMain, Blk.TotBytesWritten/1024);
     msg(MsgTxt, 0);
     
     return EndProcess(GlobalErrorFlag);

--- a/sfklZip.cpp
+++ b/sfklZip.cpp
@@ -26,7 +26,7 @@
 ULONG	UnMemcomp(const BYTE *InBuf, int InBytes, BYTE *OutBuf, int OutBufLen)
 {
     // Uncompress buffer using ZLIBs uncompress function...
-    ULONG	OutBytes = OutBufLen;
+    unsigned long OutBytes = OutBufLen;
     int Result = uncompress(OutBuf, &OutBytes, InBuf, InBytes);
     if (Result != Z_OK)				// uncompress failed?
     {

--- a/wcc.h
+++ b/wcc.h
@@ -67,17 +67,17 @@
 // ----- typdefs -----
 typedef unsigned short		USHORT;
 typedef unsigned char		BYTE;
-typedef unsigned long		ULONG;
+typedef unsigned int		ULONG;
 //typedef int			bool;
 
-typedef short							AWORD;				// Audio word (i.e., 16-bit audio)
+typedef short			AWORD;		// Audio word, i.e. 16-bit audio
 typedef unsigned short		UAWORD;
-typedef long		 					LAWORD;				// "long" audio word i.e. 32 bits
-typedef unsigned long			ULAWORD;
+typedef int			LAWORD;		// "long" audio word, i.e. 32 bits
+typedef unsigned int		ULAWORD;
 
 // Types used by Bit I/O (BIO) routines...
-typedef USHORT					BIOWORD;   
-typedef ULONG						BIOWORD2;
+typedef USHORT					BIOWORD;
+typedef ULONG					BIOWORD2;
 
 // -------------------
 


### PR DESCRIPTION
- supercedes the Debian patches from #9/#10
  - moves the `.so` to `.so.NUMBER*` change to variables
  - does that for GNU (Linux, kFreeBSD, Hurd) only
  - adds support for `.so.MAJOR.MINOR` scheme some BSDs use
    - note which BSDs use it, and that others might need more patches
  - uses `install -D` only on GNU
  - leaves all other OSes alone
  - handles Debian’s multiarch libdir transparently for modern-style library installs on GNU distros
  - allows overriding `LIBDIR` for legacy GNU/Linux distros like ROSA Linux, https://github.com/raboof/sfArkLib/issues/11
- adds the patch from #12 bumping the ABI major with it

this should be compatible (i.e. merging both without conflicts) with #16